### PR TITLE
feat(ui,auth): redesign admin dashboard cards to compact left-icon layout; remove login success modal for instant redirect

### DIFF
--- a/src/admin/Dashboard.vue
+++ b/src/admin/Dashboard.vue
@@ -106,88 +106,75 @@
       </div> 
       
       <template v-else>
-        <!-- Main Metrics Row - All 5 cards in one horizontal row -->
+        <!-- Main Metrics Row - Stacked on mobile, responsive on larger screens -->
         <section>
-          <div class="grid grid-cols-5 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-2 sm:gap-4 md:gap-6">
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4 sm:gap-6">
             <!-- Registered Users -->
-            <div class="group relative bg-gradient-to-br from-white via-blue-50/30 to-blue-100/20 rounded-lg sm:rounded-2xl p-2 sm:p-4 md:p-6 shadow-md sm:shadow-lg hover:shadow-xl sm:hover:shadow-2xl border border-blue-200/50 transition-all duration-300 hover:-translate-y-0.5 sm:hover:-translate-y-1 hover:scale-102 sm:hover:scale-105 overflow-hidden min-h-[80px] sm:min-h-[150px]">
-              <div class="absolute inset-0 bg-gradient-to-br from-blue-500/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-              <div class="relative flex flex-col sm:flex-row items-center gap-1 sm:gap-3 md:gap-4 h-full">
-                <div class="relative w-6 h-6 sm:w-10 sm:h-10 md:w-12 md:h-12 rounded-md sm:rounded-xl bg-gradient-to-br from-blue-100 to-blue-200 flex items-center justify-center shadow-md sm:shadow-lg group-hover:shadow-lg sm:group-hover:shadow-xl transition-all duration-300 group-hover:scale-105 sm:group-hover:scale-110">
-                  <div class="absolute inset-0 bg-gradient-to-br from-blue-400/20 to-transparent rounded-md sm:rounded-xl"></div>
-                  <svg class="relative w-3 h-3 sm:w-5 sm:h-5 md:w-6 md:h-6 text-blue-600 group-hover:text-blue-700 transition-colors duration-300" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clip-rule="evenodd"/></svg>
+            <div class="relative bg-white rounded-xl p-4 sm:p-5 shadow-sm border border-gray-100 overflow-hidden min-h-[90px] sm:min-h-[110px]">
+              <div class="flex items-center h-full gap-4">
+                <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-lg bg-blue-50 flex items-center justify-center">
+                  <svg class="w-5 h-5 sm:w-6 sm:h-6 text-blue-600" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clip-rule="evenodd"/></svg>
                 </div>
-                <div class="flex-1 min-w-0 text-center sm:text-left flex flex-col justify-center h-full">
-                  <div class="text-[8px] sm:text-xs md:text-sm text-gray-700 font-semibold mb-0.5 sm:mb-1 group-hover:text-gray-800 transition-colors duration-300">
-                    <span class="sm:hidden">Users</span>
-                    <span class="hidden sm:block">Registered Users</span>
-                  </div>
-                  <div class="text-sm sm:text-2xl md:text-3xl font-black text-gray-900 group-hover:text-blue-900 transition-colors duration-300 text-center sm:text-left">{{ stats.totals.card_users }}</div>
-                  <div class="text-[7px] sm:text-[10px] md:text-xs text-blue-600 font-medium mt-auto pt-1 sm:pt-0 sm:mt-1 bg-blue-100/50 px-1 sm:px-2 py-0.5 rounded-full inline-block">Today: {{ last(stats.series?.data?.card_users) }}</div>
+                <div class="flex-1">
+                  <div class="text-xs sm:text-sm text-gray-500 font-medium leading-tight">Registered Users</div>
+                  <div class="text-3xl sm:text-3xl font-black text-gray-900 leading-none">{{ stats.totals.card_users }}</div>
+                  <div class="text-xs text-blue-600 leading-tight mt-0.5">Today: {{ last(stats.series?.data?.card_users) }}</div>
                 </div>
               </div>
             </div>
 
             <!-- Cards -->
-            <div class="group relative bg-gradient-to-br from-white via-purple-50/30 to-purple-100/20 rounded-lg sm:rounded-2xl p-2 sm:p-4 md:p-6 shadow-md sm:shadow-lg hover:shadow-xl sm:hover:shadow-2xl border border-purple-200/50 transition-all duration-300 hover:-translate-y-0.5 sm:hover:-translate-y-1 hover:scale-102 sm:hover:scale-105 overflow-hidden min-h-[80px] sm:min-h-[150px]">
-              <div class="absolute inset-0 bg-gradient-to-br from-purple-500/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-              <div class="relative flex flex-col sm:flex-row items-center gap-1 sm:gap-3 md:gap-4 h-full">
-                <div class="relative w-6 h-6 sm:w-10 sm:h-10 md:w-12 md:h-12 rounded-md sm:rounded-xl bg-gradient-to-br from-purple-100 to-purple-200 flex items-center justify-center shadow-md sm:shadow-lg group-hover:shadow-lg sm:group-hover:shadow-xl transition-all duration-300 group-hover:scale-105 sm:group-hover:scale-110">
-                  <div class="absolute inset-0 bg-gradient-to-br from-purple-400/20 to-transparent rounded-md sm:rounded-xl"></div>
-                  <svg class="relative w-3 h-3 sm:w-5 sm:h-5 md:w-6 md:h-6 text-purple-600 group-hover:text-purple-700 transition-colors duration-300" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M4 4a2 2 0 00-2 2v8a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2H4zm2 6a2 2 0 114 0 2 2 0 01-4 0zm8 0a2 2 0 114 0 2 2 0 01-4 0z" clip-rule="evenodd"/></svg>
+            <div class="relative bg-white rounded-xl p-4 sm:p-5 shadow-sm border border-gray-100 overflow-hidden min-h-[90px] sm:min-h-[110px]">
+              <div class="flex items-center h-full gap-4">
+                <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-lg bg-purple-50 flex items-center justify-center">
+                  <svg class="w-5 h-5 sm:w-6 sm:h-6 text-purple-600" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M4 4a2 2 0 00-2 2v8a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2H4zm2 6a2 2 0 114 0 2 2 0 01-4 0zm8 0a2 2 0 114 0 2 2 0 01-4 0z" clip-rule="evenodd"/></svg>
                 </div>
-                <div class="flex-1 min-w-0 text-center sm:text-left flex flex-col justify-center h-full">
-                  <div class="text-[8px] sm:text-xs md:text-sm text-gray-700 font-semibold mb-0.5 sm:mb-1 group-hover:text-gray-800 transition-colors duration-300">Cards</div>
-                  <div class="text-sm sm:text-2xl md:text-3xl font-black text-gray-900 group-hover:text-purple-900 transition-colors duration-300 text-center sm:text-left">{{ stats.totals.cards }}</div>
-                  <div class="text-[7px] sm:text-[10px] md:text-xs text-purple-600 font-medium mt-auto pt-1 sm:pt-0 sm:mt-1 bg-purple-100/50 px-1 sm:px-2 py-0.5 rounded-full inline-block">Today: {{ last(stats.series?.data?.cards) }}</div>
+                <div class="flex-1">
+                  <div class="text-xs sm:text-sm text-gray-500 font-medium leading-tight">Cards</div>
+                  <div class="text-3xl sm:text-3xl font-black text-gray-900 leading-none">{{ stats.totals.cards }}</div>
+                  <div class="text-xs text-purple-600 leading-tight mt-0.5">Today: {{ last(stats.series?.data?.cards) }}</div>
                 </div>
               </div>
             </div>
 
             <!-- Activated -->
-            <div class="group relative bg-gradient-to-br from-white via-green-50/30 to-green-100/20 rounded-lg sm:rounded-2xl p-2 sm:p-4 md:p-6 shadow-md sm:shadow-lg hover:shadow-xl sm:hover:shadow-2xl border border-green-200/50 transition-all duration-300 hover:-translate-y-0.5 sm:hover:-translate-y-1 hover:scale-102 sm:hover:scale-105 overflow-hidden min-h-[80px] sm:min-h-[150px]">
-              <div class="absolute inset-0 bg-gradient-to-br from-green-500/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-              <div class="relative flex flex-col sm:flex-row items-center gap-1 sm:gap-3 md:gap-4 h-full">
-                <div class="relative w-6 h-6 sm:w-10 sm:h-10 md:w-12 md:h-12 rounded-md sm:rounded-xl bg-gradient-to-br from-green-100 to-green-200 flex items-center justify-center shadow-md sm:shadow-lg group-hover:shadow-lg sm:group-hover:shadow-xl transition-all duration-300 group-hover:scale-105 sm:group-hover:scale-110">
-                  <div class="absolute inset-0 bg-gradient-to-br from-green-400/20 to-transparent rounded-md sm:rounded-xl"></div>
-                  <svg class="relative w-3 h-3 sm:w-5 sm:h-5 md:w-6 md:h-6 text-green-600 group-hover:text-green-700 transition-colors duration-300" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+            <div class="relative bg-white rounded-xl p-4 sm:p-5 shadow-sm border border-gray-100 overflow-hidden min-h-[90px] sm:min-h-[110px]">
+              <div class="flex items-center h-full gap-4">
+                <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-lg bg-green-50 flex items-center justify-center">
+                  <svg class="w-5 h-5 sm:w-6 sm:h-6 text-green-600" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
                 </div>
-                <div class="flex-1 min-w-0 text-center sm:text-left flex flex-col justify-center h-full">
-                  <div class="text-[8px] sm:text-xs md:text-sm text-gray-700 font-semibold mb-0.5 sm:mb-1 group-hover:text-gray-800 transition-colors duration-300">Activated</div>
-                  <div class="text-sm sm:text-2xl md:text-3xl font-black text-gray-900 group-hover:text-green-900 transition-colors duration-300 text-center sm:text-left">{{ stats.totals.activated_cards }}</div>
-                  <div class="text-[7px] sm:text-[10px] md:text-xs text-green-600 font-medium mt-auto pt-1 sm:pt-0 sm:mt-1 bg-green-100/50 px-1 sm:px-2 py-0.5 rounded-full inline-block">Today: {{ last(stats.series?.data?.activations) }}</div>
+                <div class="flex-1">
+                  <div class="text-xs sm:text-sm text-gray-500 font-medium leading-tight">Activated</div>
+                  <div class="text-3xl sm:text-3xl font-black text-gray-900 leading-none">{{ stats.totals.activated_cards }}</div>
+                  <div class="text-xs text-green-600 leading-tight mt-0.5">Today: {{ last(stats.series?.data?.activations) }}</div>
                 </div>
               </div>
             </div>
 
             <!-- Expired Cards -->
-            <div class="group relative bg-gradient-to-br from-white via-orange-50/30 to-orange-100/20 rounded-lg sm:rounded-2xl p-2 sm:p-4 md:p-6 shadow-md sm:shadow-lg hover:shadow-xl sm:hover:shadow-2xl border border-orange-200/50 transition-all duration-300 hover:-translate-y-0.5 sm:hover:-translate-y-1 hover:scale-102 sm:hover:scale-105 overflow-hidden min-h-[80px] sm:min-h-[150px]">
-              <div class="absolute inset-0 bg-gradient-to-br from-orange-500/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-              <div class="relative flex flex-col sm:flex-row items-center gap-1 sm:gap-3 md:gap-4 h-full">
-                <div class="relative w-6 h-6 sm:w-10 sm:h-10 md:w-12 md:h-12 rounded-md sm:rounded-xl bg-gradient-to-br from-orange-100 to-orange-200 flex items-center justify-center shadow-md sm:shadow-lg group-hover:shadow-lg sm:group-hover:shadow-xl transition-all duration-300 group-hover:scale-105 sm:group-hover:scale-110">
-                  <div class="absolute inset-0 bg-gradient-to-br from-orange-400/20 to-transparent rounded-md sm:rounded-xl"></div>
-                  <svg class="relative w-3 h-3 sm:w-5 sm:h-5 md:w-6 md:h-6 text-orange-600 group-hover:text-orange-700 transition-colors duration-300" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/></svg>
+            <div class="relative bg-white rounded-xl p-4 sm:p-5 shadow-sm border border-gray-100 overflow-hidden min-h-[90px] sm:min-h-[110px]">
+              <div class="flex items-center h-full gap-4">
+                <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-lg bg-orange-50 flex items-center justify-center">
+                  <svg class="w-5 h-5 sm:w-6 sm:h-6 text-orange-600" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/></svg>
                 </div>
-                <div class="flex-1 min-w-0 text-center sm:text-left flex flex-col justify-center h-full">
-                  <div class="text-[8px] sm:text-xs md:text-sm text-gray-700 font-semibold mb-0.5 sm:mb-1 group-hover:text-gray-800 transition-colors duration-300">Expired Cards</div>
-                  <div class="text-sm sm:text-2xl md:text-3xl font-black text-gray-900 group-hover:text-orange-900 transition-colors duration-300 text-center sm:text-left">{{ stats.totals.expired_cards }}</div>
-                  <div class="text-[7px] sm:text-[10px] md:text-xs text-orange-600 font-medium mt-auto pt-1 sm:pt-0 sm:mt-1 bg-orange-100/50 px-1 sm:px-2 py-0.5 rounded-full inline-block">Expired</div>
+                <div class="flex-1">
+                  <div class="text-xs sm:text-sm text-gray-500 font-medium leading-tight">Expired Cards</div>
+                  <div class="text-3xl sm:text-3xl font-black text-gray-900 leading-none">{{ stats.totals.expired_cards }}</div>
+                  <div class="text-xs text-orange-600 leading-tight mt-0.5">Expired</div>
                 </div>
               </div>
             </div>
 
             <!-- Taps / Day -->
-            <div class="group relative bg-gradient-to-br from-white via-pink-50/30 to-pink-100/20 rounded-lg sm:rounded-2xl p-2 sm:p-4 md:p-6 shadow-md sm:shadow-lg hover:shadow-xl sm:hover:shadow-2xl border border-pink-200/50 transition-all duration-300 hover:-translate-y-0.5 sm:hover:-translate-y-1 hover:scale-102 sm:hover:scale-105 overflow-hidden min-h-[80px] sm:min-h-[150px]">
-              <div class="absolute inset-0 bg-gradient-to-br from-pink-500/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-              <div class="relative flex flex-col sm:flex-row items-center gap-1 sm:gap-3 md:gap-4 h-full">
-                <div class="relative w-6 h-6 sm:w-10 sm:h-10 md:w-12 md:h-12 rounded-md sm:rounded-xl bg-gradient-to-br from-pink-100 to-pink-200 flex items-center justify-center shadow-md sm:shadow-lg group-hover:shadow-lg sm:group-hover:shadow-xl transition-all duration-300 group-hover:scale-105 sm:group-hover:scale-110">
-                  <div class="absolute inset-0 bg-gradient-to-br from-pink-400/20 to-transparent rounded-md sm:rounded-xl"></div>
-                  <svg class="relative w-3 h-3 sm:w-5 sm:h-5 md:w-6 md:h-6 text-pink-600 group-hover:text-pink-700 transition-colors duration-300" fill="currentColor" viewBox="0 0 20 20"><path d="M10 12a2 2 0 100-4 2 2 0 000 4z"/><path fill-rule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clip-rule="evenodd"/></svg>
+            <div class="relative bg-white rounded-xl p-4 sm:p-5 shadow-sm border border-gray-100 overflow-hidden min-h-[90px] sm:min-h-[110px]">
+              <div class="flex items-center h-full gap-4">
+                <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-lg bg-pink-50 flex items-center justify-center">
+                  <svg class="w-5 h-5 sm:w-6 sm:h-6 text-pink-600" fill="currentColor" viewBox="0 0 20 20"><path d="M10 12a2 2 0 100-4 2 2 0 000 4z"/><path fill-rule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clip-rule="evenodd"/></svg>
                 </div>
-                <div class="flex-1 min-w-0 text-center sm:text-left flex flex-col justify-center h-full">
-                  <div class="text-[8px] sm:text-xs md:text-sm text-gray-700 font-semibold mb-0.5 sm:mb-1 group-hover:text-gray-800 transition-colors duration-300">Taps / Day</div>
-                  <div class="text-sm sm:text-2xl md:text-3xl font-black text-gray-900 group-hover:text-pink-900 transition-colors duration-300 text-center sm:text-left">{{ last(stats.series?.data?.taps) }}</div>
-                  <div class="text-[7px] sm:text-[10px] md:text-xs text-pink-600 font-medium mt-auto pt-1 sm:pt-0 sm:mt-1 bg-pink-100/50 px-1 sm:px-2 py-0.5 rounded-full inline-block">vs. yesterday: {{ deltaSign(last(stats.series?.data?.taps) - secondLast(stats.series?.data?.taps)) }}</div>
+                <div class="flex-1">
+                  <div class="text-xs sm:text-sm text-gray-500 font-medium leading-tight">Taps / Day</div>
+                  <div class="text-3xl sm:text-3xl font-black text-gray-900 leading-none">{{ last(stats.series?.data?.taps) }}</div>
+                  <div class="text-xs text-pink-600 leading-tight mt-0.5">vs. yesterday: {{ deltaSign(last(stats.series?.data?.taps) - secondLast(stats.series?.data?.taps)) }}</div>
                 </div>
               </div>
             </div>
@@ -195,68 +182,60 @@
         </section>
 
         <!-- Contact Metrics Row -->
-        <section class="mt-4 sm:mt-6">
-          <div class="grid grid-cols-4 sm:grid-cols-2 xl:grid-cols-4 gap-2 sm:gap-4 md:gap-6">
+        <section class="mt-6 sm:mt-8">
+          <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 sm:gap-6">
             <!-- Email Addresses -->
-            <div class="group relative bg-gradient-to-br from-white via-blue-50/30 to-blue-100/20 rounded-lg sm:rounded-2xl p-2 sm:p-4 md:p-6 shadow-md sm:shadow-lg hover:shadow-xl sm:hover:shadow-2xl border border-blue-200/50 transition-all duration-300 hover:-translate-y-0.5 sm:hover:-translate-y-1 hover:scale-102 sm:hover:scale-105 overflow-hidden min-h-[80px] sm:min-h-[150px]">
-              <div class="absolute inset-0 bg-gradient-to-br from-blue-500/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-              <div class="relative flex flex-col sm:flex-row items-center gap-1 sm:gap-3 md:gap-4 h-full">
-                <div class="relative w-6 h-6 sm:w-10 sm:h-10 md:w-12 md:h-12 rounded-md sm:rounded-xl bg-gradient-to-br from-blue-100 to-blue-200 flex items-center justify-center shadow-md sm:shadow-lg group-hover:shadow-lg sm:group-hover:shadow-xl transition-all duration-300 group-hover:scale-105 sm:group-hover:scale-110">
-                  <div class="absolute inset-0 bg-gradient-to-br from-blue-400/20 to-transparent rounded-md sm:rounded-xl"></div>
-                  <svg class="relative w-3 h-3 sm:w-5 sm:h-5 md:w-6 md:h-6 text-blue-600 group-hover:text-blue-700 transition-colors duration-300" fill="currentColor" viewBox="0 0 20 20"><path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z"/><path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z"/></svg>
+            <div class="relative bg-white rounded-xl p-4 sm:p-5 shadow-sm border border-gray-100 overflow-hidden min-h-[90px] sm:min-h-[110px]">
+              <div class="flex items-center h-full gap-4">
+                <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-lg bg-blue-50 flex items-center justify-center">
+                  <svg class="w-5 h-5 sm:w-6 sm:h-6 text-blue-600" fill="currentColor" viewBox="0 0 20 20"><path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z"/><path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z"/></svg>
                 </div>
-                <div class="flex-1 min-w-0 text-center sm:text-left flex flex-col justify-center h-full">
-                  <div class="text-[8px] sm:text-xs md:text-sm text-gray-700 font-semibold mb-0.5 sm:mb-1 group-hover:text-gray-800 transition-colors duration-300">Email Addresses</div>
-                  <div class="text-sm sm:text-2xl md:text-3xl font-black text-gray-900 group-hover:text-blue-900 transition-colors duration-300 text-center sm:text-left">{{ stats.totals.emails }}</div>
-                  <div class="text-[7px] sm:text-[10px] md:text-xs text-blue-600 font-medium mt-auto pt-1 sm:pt-0 sm:mt-1 bg-blue-100/50 px-1 sm:px-2 py-0.5 rounded-full inline-block">Contact Info</div>
+                <div class="flex-1">
+                  <div class="text-xs sm:text-sm text-gray-500 font-medium leading-tight">Email Addresses</div>
+                  <div class="text-3xl sm:text-3xl font-black text-gray-900 leading-none">{{ stats.totals.emails }}</div>
+                  <div class="text-xs text-blue-600 leading-tight mt-0.5">Contact Info</div>
                 </div>
               </div>
             </div>
 
             <!-- Contact Numbers -->
-            <div class="group relative bg-gradient-to-br from-white via-green-50/30 to-green-100/20 rounded-lg sm:rounded-2xl p-2 sm:p-4 md:p-6 shadow-md sm:shadow-lg hover:shadow-xl sm:hover:shadow-2xl border border-green-200/50 transition-all duration-300 hover:-translate-y-0.5 sm:hover:-translate-y-1 hover:scale-102 sm:hover:scale-105 overflow-hidden min-h-[80px] sm:min-h-[150px]">
-              <div class="absolute inset-0 bg-gradient-to-br from-green-500/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-              <div class="relative flex flex-col sm:flex-row items-center gap-1 sm:gap-3 md:gap-4 h-full">
-                <div class="relative w-6 h-6 sm:w-10 sm:h-10 md:w-12 md:h-12 rounded-md sm:rounded-xl bg-gradient-to-br from-green-100 to-green-200 flex items-center justify-center shadow-md sm:shadow-lg group-hover:shadow-lg sm:group-hover:shadow-xl transition-all duration-300 group-hover:scale-105 sm:group-hover:scale-110">
-                  <div class="absolute inset-0 bg-gradient-to-br from-green-400/20 to-transparent rounded-md sm:rounded-xl"></div>
-                  <svg class="relative w-3 h-3 sm:w-5 sm:h-5 md:w-6 md:h-6 text-green-600 group-hover:text-green-700 transition-colors duration-300" fill="currentColor" viewBox="0 0 20 20"><path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z"/></svg>
+            <div class="relative bg-white rounded-xl p-4 sm:p-5 shadow-sm border border-gray-100 overflow-hidden min-h-[90px] sm:min-h-[110px]">
+              <div class="flex items-center h-full gap-4">
+                <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-lg bg-green-50 flex items-center justify-center">
+                  <svg class="w-5 h-5 sm:w-6 sm:h-6 text-green-600" fill="currentColor" viewBox="0 0 20 20"><path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z"/></svg>
                 </div>
-                <div class="flex-1 min-w-0 text-center sm:text-left flex flex-col justify-center h-full">
-                  <div class="text-[8px] sm:text-xs md:text-sm text-gray-700 font-semibold mb-0.5 sm:mb-1 group-hover:text-gray-800 transition-colors duration-300">Contact Numbers</div>
-                  <div class="text-sm sm:text-2xl md:text-3xl font-black text-gray-900 group-hover:text-green-900 transition-colors duration-300 text-center sm:text-left">{{ stats.totals.phones }}</div>
-                  <div class="text-[7px] sm:text-[10px] md:text-xs text-green-600 font-medium mt-auto pt-1 sm:pt-0 sm:mt-1 bg-green-100/50 px-1 sm:px-2 py-0.5 rounded-full inline-block">Phone Numbers</div>
+                <div class="flex-1">
+                  <div class="text-xs sm:text-sm text-gray-500 font-medium leading-tight">Contact Numbers</div>
+                  <div class="text-3xl sm:text-3xl font-black text-gray-900 leading-none">{{ stats.totals.phones }}</div>
+                  <div class="text-xs text-green-600 leading-tight mt-0.5">Phone Numbers</div>
                 </div>
               </div>
             </div>
 
             <!-- Social Links -->
-            <div class="group relative bg-gradient-to-br from-white via-purple-50/30 to-purple-100/20 rounded-lg sm:rounded-2xl p-2 sm:p-4 md:p-6 shadow-md sm:shadow-lg hover:shadow-xl sm:hover:shadow-2xl border border-purple-200/50 transition-all duration-300 hover:-translate-y-0.5 sm:hover:-translate-y-1 hover:scale-102 sm:hover:scale-105 overflow-hidden min-h-[80px] sm:min-h-[150px]">
-              <div class="absolute inset-0 bg-gradient-to-br from-purple-500/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-              <div class="relative flex flex-col sm:flex-row items-center gap-1 sm:gap-3 md:gap-4 h-full">
-                <div class="relative w-6 h-6 sm:w-10 sm:h-10 md:w-12 md:h-12 rounded-md sm:rounded-xl bg-gradient-to-br from-purple-100 to-purple-200 flex items-center justify-center shadow-md sm:shadow-lg group-hover:shadow-lg sm:group-hover:shadow-xl transition-all duration-300 group-hover:scale-105 sm:group-hover:scale-110">
-                  <div class="absolute inset-0 bg-gradient-to-br from-purple-400/20 to-transparent rounded-md sm:rounded-xl"></div>
-                  <svg class="relative w-3 h-3 sm:w-5 sm:h-5 md:w-6 md:h-6 text-purple-600 group-hover:text-purple-700 transition-colors duration-300" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M12.316 3.051a1 1 0 01.633 1.265l-4 12a1 1 0 11-1.898-.632l4-12a1 1 0 011.265-.633zM5.707 6.293a1 1 0 010 1.414L3.414 10l2.293 2.293a1 1 0 11-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0zm8.586 0a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 11-1.414-1.414L16.586 10l-2.293-2.293a1 1 0 010-1.414z" clip-rule="evenodd"/></svg>
+            <div class="relative bg-white rounded-xl p-4 sm:p-5 shadow-sm border border-gray-100 overflow-hidden min-h-[90px] sm:min-h-[110px]">
+              <div class="flex items-center h-full gap-4">
+                <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-lg bg-purple-50 flex items-center justify-center">
+                  <svg class="w-5 h-5 sm:w-6 sm:h-6 text-purple-600" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M12.316 3.051a1 1 0 01.633 1.265l-4 12a1 1 0 11-1.898-.632l4-12a1 1 0 011.265-.633zM5.707 6.293a1 1 0 010 1.414L3.414 10l2.293 2.293a1 1 0 11-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0zm8.586 0a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 11-1.414-1.414L16.586 10l-2.293-2.293a1 1 0 010-1.414z" clip-rule="evenodd"/></svg>
                 </div>
-                <div class="flex-1 min-w-0 text-center sm:text-left flex flex-col justify-center h-full">
-                  <div class="text-[8px] sm:text-xs md:text-sm text-gray-700 font-semibold mb-0.5 sm:mb-1 group-hover:text-gray-800 transition-colors duration-300">Social Links</div>
-                  <div class="text-sm sm:text-2xl md:text-3xl font-black text-gray-900 group-hover:text-purple-900 transition-colors duration-300 text-center sm:text-left">{{ stats.totals.socials }}</div>
-                  <div class="text-[7px] sm:text-[10px] md:text-xs text-purple-600 font-medium mt-auto pt-1 sm:pt-0 sm:mt-1 bg-purple-100/50 px-1 sm:px-2 py-0.5 rounded-full inline-block">Social Media</div>
+                <div class="flex-1">
+                  <div class="text-xs sm:text-sm text-gray-500 font-medium leading-tight">Social Links</div>
+                  <div class="text-3xl sm:text-3xl font-black text-gray-900 leading-none">{{ stats.totals.socials }}</div>
+                  <div class="text-xs text-purple-600 leading-tight mt-0.5">Social Media</div>
                 </div>
               </div>
             </div>
 
             <!-- Other Links -->
-            <div class="group relative bg-gradient-to-br from-white via-orange-50/30 to-orange-100/20 rounded-lg sm:rounded-2xl p-2 sm:p-4 md:p-6 shadow-md sm:shadow-lg hover:shadow-xl sm:hover:shadow-2xl border border-orange-200/50 transition-all duration-300 hover:-translate-y-0.5 sm:hover:-translate-y-1 hover:scale-102 sm:hover:scale-105 overflow-hidden min-h-[80px] sm:min-h-[150px]">
-              <div class="absolute inset-0 bg-gradient-to-br from-orange-500/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-              <div class="relative flex flex-col sm:flex-row items-center gap-1 sm:gap-3 md:gap-4 h-full">
-                <div class="relative w-6 h-6 sm:w-10 sm:h-10 md:w-12 md:h-12 rounded-md sm:rounded-xl bg-gradient-to-br from-orange-100 to-orange-200 flex items-center justify-center shadow-md sm:shadow-lg group-hover:shadow-lg sm:group-hover:shadow-xl transition-all duration-300 group-hover:scale-105 sm:group-hover:scale-110">
-                  <div class="absolute inset-0 bg-gradient-to-br from-orange-400/20 to-transparent rounded-md sm:rounded-xl"></div>
-                  <svg class="relative w-3 h-3 sm:w-5 sm:h-5 md:w-6 md:h-6 text-orange-600 group-hover:text-orange-700 transition-colors duration-300" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M12.586 4.586a2 2 0 112.828 2.828l-3 3a2 2 0 01-2.828 0 1 1 0 00-1.414 1.414 4 4 0 005.656 0l3-3a4 4 0 00-5.656-5.656l-1.5 1.5a1 1 0 101.414 1.414l1.5-1.5zm-5 5a2 2 0 012.828 0 1 1 0 101.414-1.414 4 4 0 00-5.656 0l-3 3a4 4 0 105.656 5.656l1.5-1.5a1 1 0 10-1.414-1.414l-1.5 1.5a2 2 0 11-2.828-2.828l3-3z" clip-rule="evenodd"/></svg>
+            <div class="relative bg-white rounded-xl p-4 sm:p-5 shadow-sm border border-gray-100 overflow-hidden min-h-[90px] sm:min-h-[110px]">
+              <div class="flex items-center h-full gap-4">
+                <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-lg bg-orange-50 flex items-center justify-center">
+                  <svg class="w-5 h-5 sm:w-6 sm:h-6 text-orange-600" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M12.586 4.586a2 2 0 112.828 2.828l-3 3a2 2 0 01-2.828 0 1 1 0 00-1.414 1.414 4 4 0 005.656 0l3-3a4 4 0 00-5.656-5.656l-1.5 1.5a1 1 0 101.414 1.414l1.5-1.5zm-5 5a2 2 0 012.828 0 1 1 0 101.414-1.414 4 4 0 00-5.656 0l-3 3a4 4 0 105.656 5.656l1.5-1.5a1 1 0 10-1.414-1.414l-1.5 1.5a2 2 0 11-2.828-2.828l3-3z" clip-rule="evenodd"/></svg>
                 </div>
-                <div class="flex-1 min-w-0 text-center sm:text-left flex flex-col justify-center h-full">
-                  <div class="text-[8px] sm:text-xs md:text-sm text-gray-700 font-semibold mb-0.5 sm:mb-1 group-hover:text-gray-800 transition-colors duration-300">Other Links</div>
-                  <div class="text-sm sm:text-2xl md:text-3xl font-black text-gray-900 group-hover:text-orange-900 transition-colors duration-300 text-center sm:text-left">{{ stats.totals.others }}</div>
-                  <div class="text-[7px] sm:text-[10px] md:text-xs text-orange-600 font-medium mt-auto pt-1 sm:pt-0 sm:mt-1 bg-orange-100/50 px-1 sm:px-2 py-0.5 rounded-full inline-block">Web Links</div>
+                <div class="flex-1">
+                  <div class="text-xs sm:text-sm text-gray-500 font-medium leading-tight">Other Links</div>
+                  <div class="text-3xl sm:text-3xl font-black text-gray-900 leading-none">{{ stats.totals.others }}</div>
+                  <div class="text-xs text-orange-600 leading-tight mt-0.5">Web Links</div>
                 </div>
               </div>
             </div>
@@ -560,23 +539,16 @@ const chartOptions = computed(() => ({
     },
     background: 'transparent'
   },
-  colors: ['#000000', '#374151', '#1D4ED8', '#DC2626'],
+  colors: ['#1F2937', '#6B7280', '#3B82F6', '#EC4899'],
   stroke: {
-    curve: 'straight',
-    width: [4, 4, 4, 5],
-    lineCap: 'round',
-    opacity: 1
-  },
-  fill: {
-    type: 'solid',
-    opacity: 1
+    curve: 'smooth',
+    width: [3, 3, 3, 4],
+    lineCap: 'round'
   },
   markers: {
     size: [4, 4, 4, 5],
     strokeWidth: 2,
     strokeColors: '#fff',
-    fillOpacity: 1,
-    strokeOpacity: 1,
     hover: {
       size: [6, 6, 6, 7]
     }


### PR DESCRIPTION
Admin dashboard (frontend/src/admin/Dashboard.vue)
Convert all stat cards to left-icon/right-text layout (title, count, subtitle)
Centered grid spacing; subtle rounded-xl, shadow-sm, border-gray-100
Replace gradient icon tiles with soft *-50 backgrounds (e.g., bg-blue-50)
Remove gradients/hover animations; tighten vertical spacing (leading-tight, mt-0.5)
Reduce min-height for compact desktop view
Apply same layout and spacing to contact metrics row
Auth login (frontend/src/user/userlogin.vue)
Remove success “redirecting…” modal and related state
Immediately redirect after successful login:
Admin → admin-dashboard
User → dashboard
Keep error modal; small cleanup (toggle password handler, unused refs)
Pull request description:

Summary
This PR modernizes the Admin Dashboard stats UI and streamlines login flow.
Rebuilt dashboard cards to match a clean reference layout:
Left-aligned icon in a soft colored square (e.g., bg-blue-50)
Right-aligned text block with a small gray title, large bold count, and a compact subtitle line
Subtle container style using rounded-xl, shadow-sm, and border-gray-100
Removed gradients and hover animations for a minimal, professional look
Reduced container heights and tightened vertical spacing for better density on desktop
Applied consistently across main metrics and contact metrics
Simplified login UX:
Removed the success/loading modal
Immediate navigation to the appropriate dashboard upon successful login (admin/user)